### PR TITLE
Add super-admin layout with header

### DIFF
--- a/app/dashboard/super-admin/components/Header.tsx
+++ b/app/dashboard/super-admin/components/Header.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useSession, signOut } from "next-auth/react";
+
+export default function Header() {
+  const { data: session } = useSession();
+  return (
+    <header className="sticky top-0 z-40 bg-white shadow flex items-center justify-between h-16 px-4 sm:px-6 border-b">
+      <span className="font-bold text-lg sm:text-xl">Super Admin Dashboard</span>
+      <div className="flex items-center gap-2 sm:gap-4">
+        <span className="text-gray-700 text-xs sm:text-base">{session?.user?.email} ({session?.user?.role})</span>
+        <button
+          onClick={() => signOut({ callbackUrl: "/login" })}
+          className="bg-red-500 text-white px-3 py-1.5 sm:px-4 sm:py-2 rounded-md text-xs sm:text-sm font-medium hover:bg-red-600"
+        >
+          Sign Out
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/app/dashboard/super-admin/layout.tsx
+++ b/app/dashboard/super-admin/layout.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import Header from "./components/Header";
+import "../../globals.css";
+
+export default function SuperAdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "authenticated" && session?.user?.role !== "super-admin") {
+      router.push("/dashboard");
+    }
+  }, [status, session, router]);
+
+  if (status === "loading") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+          <p className="mt-4 text-gray-600">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen flex flex-col bg-gray-50">
+      <Header />
+      <main className="flex-1 overflow-y-auto p-2 sm:p-4 md:p-6">{children}</main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add header with sign out button for super admin section
- provide layout wrapping super admin pages

## Testing
- `npm run lint` *(fails: `next` not found)*