### PR TITLE
Handle NextAuth route errors

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,3 +1,22 @@
-import { GET, POST } from "@/auth";
+import { GET as nextAuthGET, POST as nextAuthPOST } from "@/auth";
+import { NextResponse } from "next/server";
 
-export { GET, POST }; 
+export async function GET(request: Request) {
+  try {
+    return await nextAuthGET(request);
+  } catch (error) {
+    console.error("[auth] GET handler error", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    return await nextAuthPOST(request);
+  } catch (error) {
+    console.error("[auth] POST handler error", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}
+
+export const runtime = "nodejs";


### PR DESCRIPTION
## Summary
- wrap NextAuth GET/POST handlers in try/catch
- ensure errors return JSON responses
- force Node runtime for auth route

## Testing
- `npm run lint` *(fails: `next: not found`)*